### PR TITLE
Render difftastic files synchronously during refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Evil is absent, this is skipped entirely — no hard dependency.
 | `magit-difftastic-syntax-highlight`     | `t`          | Layer the file's Emacs major-mode font-lock faces onto each chunk's code (difft only emphasizes keywords/comments). Diff colors keep precedence. Adds per-file fontification cost; set `nil` to disable. |
 | `magit-difftastic-width`                | `window`     | Column width passed to difft, controlling where it wraps long lines: `window` (fit the window) or an integer (fixed columns; larger wraps less). |
 | `magit-difftastic-min-width`            | `40`         | Minimum column width requested from difft. |
-| `magit-difftastic-render-jobs`          | `nil`        | Maximum number of `difft` processes run concurrently per refresh. `nil` uses the processor count (capped); a positive integer sets a fixed limit (`1` renders serially). |
+| `magit-difftastic-render-jobs`          | `nil`        | Obsolete; rendering is now synchronous during Magit refresh. |
 | `magit-difftastic-cache`                | `t`          | Cache rendered difft output across refreshes, keyed on the compared blobs (plus display and width), so unchanged files are not re-rendered. Clear with `magit-difftastic-clear-cache`. |
 | `magit-difftastic-chunk-heading-face`   | `magit-diff-hunk-heading` | Face for the per-chunk `@@ line N @@` headings. Defaults to Magit's hunk-heading face (a full-width bar); set to e.g. `magit-hash` for understated headings. |
 | `magit-difftastic-apply-context`        | `1`          | Context lines for the git hunks used to stage/unstage chunks. Must be `>= 1`. |
@@ -180,12 +180,11 @@ evil-state-agnostic.
 - Region staging operates within a single chunk; whole-chunk staging snaps to
   the underlying git-hunk boundary (the same one Magit's per-hunk staging uses).
 - `difft` runs once per changed file when its content first needs rendering.
-  Files in a section are rendered concurrently (up to `magit-difftastic-render-jobs`
-  at a time) and the output is cached across refreshes keyed on the compared
-  blobs (`magit-difftastic-cache`), so unchanged files are not re-rendered — a
-  refresh costs roughly the slowest file that actually changed. A very large set
-  of first-time changes can still feel sluggish, since the refresh waits for that
-  initial batch. Clear the cache with `M-x magit-difftastic-clear-cache`.
+  The output is cached across refreshes keyed on the compared blobs
+  (`magit-difftastic-cache`), so unchanged files are not re-rendered. A very
+  large set of first-time changes can still feel sluggish, since the refresh
+  waits for that initial batch. Clear the cache with
+  `M-x magit-difftastic-clear-cache`.
 - Untracked files use the stock `magit-insert-untracked-files`.
 - In `magit-diff-mode` / `magit-revision-mode`, difftastic replaces Magit's diff
   section wholesale, so the diffstat header isn't shown. Merge commits and

--- a/magit-difftastic.el
+++ b/magit-difftastic.el
@@ -122,13 +122,10 @@
 ;;     that contains it.  Whole-chunk staging snaps to the underlying git hunk
 ;;     boundary -- the same boundary Magit's own per-hunk staging uses.
 ;;   - `difft' is run once per changed file when its content first needs
-;;     rendering.  Files in a section are rendered concurrently (up to
-;;     `magit-difftastic-render-jobs' processes at a time) and the result is
-;;     cached across refreshes keyed on the compared blobs (see
-;;     `magit-difftastic-cache'), so an unchanged file is not re-rendered -- a
-;;     refresh costs roughly the slowest file that actually changed.  A very
-;;     large set of first-time changes can still make `magit-status' sluggish,
-;;     since the refresh waits for that initial batch.
+;;     rendering.  Rendered output is cached across refreshes keyed on the
+;;     compared blobs (see `magit-difftastic-cache'), so an unchanged file is
+;;     not re-rendered.  A very large set of first-time changes can still make
+;;     `magit-status' sluggish, since the refresh waits for that initial batch.
 ;;   - Untracked files are still rendered by the stock
 ;;     `magit-insert-untracked-files'.
 ;;   - In `magit-diff-mode'/`magit-revision-mode' buffers the difftastic
@@ -244,17 +241,12 @@ At least `magit-difftastic-min-width' columns are always used.  The
   :group 'magit-difftastic)
 
 (defcustom magit-difftastic-render-jobs nil
-  "Maximum number of `difft' processes to run concurrently while rendering.
-On every refresh each changed file is rendered by its own `difft' subprocess;
-running them concurrently makes the rendering wall-clock time roughly the
-slowest single file rather than the sum of all of them.
-
-  - nil (default): use the number of available processors (when Emacs can
-    report it), capped at a sensible maximum, else a small fixed number.
-  - a positive integer: run at most that many `difft' processes at once.  A
-    value of 1 renders serially (the pre-2.x behaviour)."
-  :type '(choice (const :tag "Auto (number of processors)" nil)
-                 (integer :tag "Fixed maximum"))
+  "Obsolete option formerly used for concurrent `difft' rendering.
+Rendering is now synchronous because Magit refresh already blocks until all
+files are rendered, and the previous async process pool could stall waiting for
+process sentinels in the middle of refresh."
+  :type '(choice (const :tag "Ignored" nil)
+                 (integer :tag "Ignored"))
   :group 'magit-difftastic)
 
 (defun magit-difftastic--width ()
@@ -276,7 +268,7 @@ The revision and the `-- FILE' pathspec are appended to this.")
 (defvar magit-difftastic--render-cache nil
   "Dynamically-bound hash of FILE -> pre-rendered difft string for one group.
 Bound in `magit-difftastic--insert-file-sections' to the result of rendering
-that group's files in parallel (see `magit-difftastic--render-files'), so the
+that group's files (see `magit-difftastic--render-files'), so the
 synchronous section-insertion pass reads each file's already-computed difft
 output instead of spawning a subprocess inline.  A cache miss falls back to a
 direct synchronous render, so the cache is purely an optimisation.")
@@ -284,7 +276,7 @@ direct synchronous render, so the cache is purely an optimisation.")
 (defun magit-difftastic--render-raw (file diff-args width)
   "Run `git DIFF-ARGS -- FILE' through difft at WIDTH and return propertized text.
 Synchronous; used as the fallback when no pre-warmed entry exists (see
-`magit-difftastic--render-cache') and as the worker the parallel runner mirrors."
+`magit-difftastic--render-cache') and by the batch renderer."
   (require 'difftastic)
   (let ((raw (with-temp-buffer
                ;; `difftastic--build-git-process-environment' sets
@@ -310,74 +302,22 @@ appended as a pathspec.  For example, `(\"--no-pager\" \"diff\" \"--ext-diff\"
 `(\"--no-pager\" \"show\" \"--ext-diff\" \"--format=\" REV)' renders a commit.
 
 When `magit-difftastic--render-cache' holds a pre-warmed entry for FILE (the
-common case during a refresh, where the whole group was rendered in parallel up
-front) it is returned directly; otherwise FILE is rendered synchronously now."
+common case during a refresh, where the whole group was rendered up front) it
+is returned directly; otherwise FILE is rendered synchronously now."
   (or (and magit-difftastic--render-cache
            (gethash file magit-difftastic--render-cache))
       (magit-difftastic--render-raw file diff-args (magit-difftastic--width))))
 
-(defun magit-difftastic--max-jobs ()
-  "Return the maximum number of concurrent difft processes to run.
-Honours `magit-difftastic-render-jobs'; when that is nil, uses the processor
-count (capped) when Emacs can report it, else a small fixed default."
-  (cond
-   ((integerp magit-difftastic-render-jobs)
-    (max 1 magit-difftastic-render-jobs))
-   ((fboundp 'num-processors) (max 1 (min 16 (num-processors))))
-   (t 4)))
-
 (defun magit-difftastic--render-files (jobs width)
-  "Render difft for JOBS in parallel; return a hash of FILE -> rendered string.
+  "Render difft for JOBS; return a hash of FILE -> rendered string.
 JOBS is a list of (FILE . DIFF-ARGS).  Each job runs `git DIFF-ARGS -- FILE'
-through difft (exactly as `magit-difftastic--render-raw' does synchronously) at
-WIDTH columns, but up to `magit-difftastic--max-jobs' of them run concurrently
-via `start-file-process' (the TRAMP-aware async counterpart of `process-file'),
-so a group's rendering cost is roughly its slowest file rather than the sum.
-
-Blocks until every job has finished, then returns the populated hash; a job
-whose process fails simply yields nil for that file, so the caller falls back to
-a synchronous render."
-  (require 'difftastic)
-  (let* ((results (make-hash-table :test 'equal))
-         (queue (copy-sequence jobs))
-         (max-jobs (magit-difftastic--max-jobs))
-         (running 0)
-         (pending (length jobs))
-         ;; difft is selected purely through the environment (GIT_EXTERNAL_DIFF
-         ;; etc.); the same env is reused for every process in the group.
-         (env (difftastic--build-git-process-environment
-               width (list "--display" magit-difftastic-display))))
-    (cl-labels
-        ((launch ()
-           (while (and queue (< running max-jobs))
-             (let* ((job (pop queue))
-                    (file (car job))
-                    (args (append (cdr job) (list "--" file)))
-                    (buf (generate-new-buffer " *magit-difftastic-render*"))
-                    (process-environment env)
-                    (proc (apply #'start-file-process
-                                 "magit-difftastic-render" buf "git" args)))
-               (cl-incf running)
-               (set-process-query-on-exit-flag proc nil)
-               (set-process-sentinel
-                proc
-                (lambda (p _event)
-                  (unless (process-live-p p)
-                    (let ((b (process-buffer p)))
-                      (when (buffer-live-p b)
-                        (with-current-buffer b
-                          (puthash file
-                                   (difftastic--ansi-color-apply (buffer-string))
-                                   results))
-                        (kill-buffer b)))
-                    (cl-decf running)
-                    (cl-decf pending)
-                    ;; A finished slot frees room for the next queued job.
-                    (launch))))))))
-      (launch)
-      ;; Pump the event loop until every sentinel has fired.
-      (while (> pending 0)
-        (accept-process-output nil 0.05)))
+through difft at WIDTH columns.  Rendering is done synchronously with
+`process-file', matching the rest of Magit's refresh path and avoiding the
+event-loop and sentinel dependency of an async process pool."
+  (let ((results (make-hash-table :test 'equal)))
+    (pcase-dolist (`(,file . ,diff-args) jobs)
+      (puthash file (magit-difftastic--render-raw file diff-args width)
+               results))
     results))
 
 ;;; Render cache
@@ -1910,7 +1850,7 @@ is the default rendering; see `magit-difftastic--insert-file-sections'."
   "Return a FILE -> rendered-string hash for RENDER-FILES of CONTEXT at WIDTH.
 Files whose content is unchanged since an earlier refresh are served from the
 persistent cache (`magit-difftastic--cache'); the remaining files are rendered
-concurrently (`magit-difftastic--render-files') and then stored in that cache.
+by `magit-difftastic--render-files' and then stored in that cache.
 Files that cannot be content-keyed (or when `magit-difftastic-cache' is nil) are
 simply rendered every time.
 
@@ -2012,7 +1952,7 @@ like it expands straight to its diff in Magit."
          ;; front (stock-rendered files and rename sources are skipped -- the
          ;; former go through `magit--insert-diff', the latter are not shown).
          ;; Unchanged files are served from the cross-refresh cache and the rest
-         ;; rendered in one parallel batch; the synchronous insertion loop below
+         ;; rendered in one batch; the synchronous insertion loop below
          ;; then reads each file's output from this hash via
          ;; `magit-difftastic--file-diff-string'.
          (magit-difftastic--render-cache

--- a/test/magit-difftastic-test.el
+++ b/test/magit-difftastic-test.el
@@ -694,11 +694,11 @@ the whitespace flags are now forwarded."
         (should (member "real.txt" files))
         (should-not (member "ws.txt" files))))))
 
-;;;; Integration: parallel rendering ---------------------------------------
+;;;; Integration: batch rendering ------------------------------------------
 
 (ert-deftest magit-difftastic-integration/render-files-matches-sync ()
-  "`--render-files' renders a batch in parallel, matching the sync path.
-Each file's parallel result must equal what `--render-raw' produces serially,
+  "`--render-files' renders a batch matching the raw render path.
+Each file's batch result must equal what `--render-raw' produces directly,
 and every requested file must be present in the returned hash."
   (skip-unless dst-test--have-tools)
   (dst-test--with-repo '(("a.txt" . "alpha\nbravo\n")
@@ -710,15 +710,15 @@ and every requested file must be present in the returned hash."
     (let* ((files '("a.txt" "b.txt" "c.txt"))
            (width (magit-difftastic--width))
            (jobs (mapcar (lambda (f) (cons f magit-difftastic--diff-base)) files))
-           (parallel (magit-difftastic--render-files jobs width)))
-      (should (= (hash-table-count parallel) (length files)))
+           (rendered (magit-difftastic--render-files jobs width)))
+      (should (= (hash-table-count rendered) (length files)))
       (dolist (f files)
-        (should (equal (gethash f parallel)
+        (should (equal (gethash f rendered)
                        (magit-difftastic--render-raw
                         f magit-difftastic--diff-base width)))))))
 
-(ert-deftest magit-difftastic-integration/render-files-serial-limit ()
-  "`--render-files' still yields correct output when limited to one job at a time."
+(ert-deftest magit-difftastic-integration/render-files-ignores-render-jobs ()
+  "`--render-files' yields correct output regardless of obsolete job limit."
   (skip-unless dst-test--have-tools)
   (dst-test--with-repo '(("a.txt" . "alpha\nbravo\n")
                          ("b.txt" . "one\ntwo\n"))
@@ -728,10 +728,10 @@ and every requested file must be present in the returned hash."
            (files '("a.txt" "b.txt"))
            (width (magit-difftastic--width))
            (jobs (mapcar (lambda (f) (cons f magit-difftastic--diff-base)) files))
-           (parallel (magit-difftastic--render-files jobs width)))
-      (should (= (hash-table-count parallel) (length files)))
+           (rendered (magit-difftastic--render-files jobs width)))
+      (should (= (hash-table-count rendered) (length files)))
       (dolist (f files)
-        (should (equal (gethash f parallel)
+        (should (equal (gethash f rendered)
                        (magit-difftastic--render-raw
                         f magit-difftastic--diff-base width)))))))
 
@@ -827,7 +827,7 @@ invocation, feeding both the caches (ids) and the file headings (status)."
                    (setq rendered-again jobs)
                    (make-hash-table :test 'equal))))
         (let ((second (magit-difftastic--prewarm files context width)))
-          ;; No misses -> the parallel renderer is never invoked.
+          ;; No misses -> the renderer is never invoked.
           (should-not rendered-again)
           (should (= (hash-table-count second) 2))
           (dolist (f files)


### PR DESCRIPTION
## Summary

Render difftastic files synchronously during Magit refresh instead of using an async process pool that is immediately waited on.

This removes the `start-file-process` / sentinel / `accept-process-output` loop from `magit-difftastic--render-files` and reuses the existing synchronous `magit-difftastic--render-raw` path for each render job. The existing render cache still prevents unchanged files from being rendered again.

`magit-difftastic-render-jobs` is left in place as an obsolete/ignored option to avoid breaking user configs, and the README/test descriptions are updated accordingly.

## Why

The previous implementation launched `difft` processes asynchronously, but then blocked Magit refresh until every sentinel had fired:

```elisp
(while (> pending 0)
  (accept-process-output nil 0.05))
```

That means the user-visible behavior was already synchronous: Magit refresh could not complete until all rendered strings were available. The async layer added extra dependencies on Emacs' process event loop, process buffers, and sentinel scheduling without actually allowing the refresh to continue in the background.

In a normal interactive Emacs session, `accept-process-output nil` can process output and sentinels for unrelated subprocesses as well. If other process filters/sentinels/timers are active, a fast `git diff --ext-diff` subprocess can still be observed as delayed because completion is only recorded once the sentinel gets scheduled and runs.

Using `process-file` keeps the refresh path deterministic: each render writes directly into a temporary buffer and returns when Git/difft exits, with no process buffer or sentinel bookkeeping in the middle.

## Validation

Passed:

```sh
emacs --batch --eval '(progn (require (quote package)) (setq package-user-dir "/Users/misaka/.config/emacs/elpa" native-comp-jit-compilation nil) (package-initialize))' -L . -L test -l test/magit-difftastic-test.el --eval '(ert-run-tests-batch-and-exit "magit-difftastic-integration/render-files")'
```

```sh
git diff --check
```
