### PR TITLE
fix: scope difftastic render process output

### DIFF
--- a/magit-difftastic.el
+++ b/magit-difftastic.el
@@ -343,6 +343,7 @@ a synchronous render."
          (max-jobs (magit-difftastic--max-jobs))
          (running 0)
          (pending (length jobs))
+         (render-processes nil)
          ;; difft is selected purely through the environment (GIT_EXTERNAL_DIFF
          ;; etc.); the same env is reused for every process in the group.
          (env (difftastic--build-git-process-environment
@@ -358,11 +359,13 @@ a synchronous render."
                     (proc (apply #'start-file-process
                                  "magit-difftastic-render" buf "git" args)))
                (cl-incf running)
+               (push proc render-processes)
                (set-process-query-on-exit-flag proc nil)
                (set-process-sentinel
                 proc
                 (lambda (p _event)
                   (unless (process-live-p p)
+                    (setq render-processes (delq p render-processes))
                     (let ((b (process-buffer p)))
                       (when (buffer-live-p b)
                         (with-current-buffer b
@@ -377,14 +380,17 @@ a synchronous render."
       (launch)
       ;; Pump the event loop until every sentinel has fired.  We run inside a
       ;; `magit-refresh', and `accept-process-output' with a nil process drains
-      ;; the whole event loop, so a foreign sentinel/timer can fire here and call
-      ;; `magit-refresh' -- which re-enters this renderer and pumps again: an
-      ;; unbounded refresh->render loop that freezes Emacs (#6).  Binding
-      ;; `magit-inhibit-refresh' (refresh's only reentrancy guard) makes any such
-      ;; nested refresh a no-op; the outer refresh already reads fresh state.
+      ;; output from every Emacs subprocess.  A foreign sentinel/timer firing
+      ;; here can slow the render wait or try to refresh Magit while we are
+      ;; already refreshing (#6).  Only accept output from the difft processes we
+      ;; started, and bind `magit-inhibit-refresh' so any nested refresh request
+      ;; remains a no-op; the outer refresh already reads fresh state.
       (let ((magit-inhibit-refresh t))
         (while (> pending 0)
-          (accept-process-output nil 0.05))))
+          (if render-processes
+              (dolist (proc (copy-sequence render-processes))
+                (accept-process-output proc 0.01 nil t))
+            (sleep-for 0.01)))))
     results))
 
 ;;; Render cache

--- a/test/magit-difftastic-test.el
+++ b/test/magit-difftastic-test.el
@@ -736,7 +736,7 @@ and every requested file must be present in the returned hash."
                         f magit-difftastic--diff-base width)))))))
 
 (ert-deftest magit-difftastic-integration/render-files-inhibits-refresh ()
-  "`--render-files' binds `magit-inhibit-refresh' while pumping the event loop.
+  "`--render-files' binds `magit-inhibit-refresh' while pumping render processes.
 Regression for the discard freeze (#6): a foreign sentinel/timer firing during
 the render pump must not be able to re-enter `magit-refresh'."
   (skip-unless dst-test--have-tools)
@@ -748,16 +748,22 @@ the render pump must not be able to re-enter `magit-refresh'."
            (width (magit-difftastic--width))
            (jobs (mapcar (lambda (f) (cons f magit-difftastic--diff-base)) files))
            (observed 'unset)
+           (process-args nil)
            (real (symbol-function 'accept-process-output)))
-      ;; The pump calls `accept-process-output' at least once to drain the
-      ;; sentinels; capture `magit-inhibit-refresh' as seen from inside it.
+      ;; The pump calls `accept-process-output' to drain the render processes;
+      ;; capture `magit-inhibit-refresh' and ensure the wait is scoped to those
+      ;; processes instead of globally accepting output with a nil process.
       (cl-letf (((symbol-function 'accept-process-output)
                  (lambda (&rest args)
                    (when (eq observed 'unset)
                      (setq observed magit-inhibit-refresh))
+                   (push (car args) process-args)
                    (apply real args))))
         (magit-difftastic--render-files jobs width))
-      (should observed))))
+      (should observed)
+      (should process-args)
+      (should-not (memq nil process-args))
+      (should (cl-every #'processp process-args)))))
 
 ;;;; Unit tests: render cache ----------------------------------------------
 


### PR DESCRIPTION
## Summary

This keeps the existing parallel difftastic rendering, but changes the wait loop so it only accepts output from the render processes started by `magit-difftastic--render-files`.

The previous loop used `accept-process-output` with a nil process argument. That drains output for every subprocess Emacs knows about, so unrelated process filters/sentinels from LSP, TRAMP, shells, completion backends, etc. can run while Magit is blocked inside a refresh. Commit 925cc8f already guarded the most dangerous refresh reentrancy case with `magit-inhibit-refresh`; this patch further narrows the process pump to avoid unrelated subprocess activity delaying or perturbing difftastic rendering.

The subprocesses are still launched in parallel with `start-file-process`. The render remains synchronous from Magit's perspective, but the wait loop is no longer a global Emacs process pump.

## Test

- `emacs --batch --eval '(progn (require (quote package)) (setq package-user-dir "/Users/misaka/.config/emacs/elpa" native-comp-jit-compilation nil) (package-initialize))' -L . -L test -l test/magit-difftastic-test.el --eval '(ert-run-tests-batch-and-exit "magit-difftastic-integration/render-files")'`\n- `git diff --check`