### PR TITLE
fix: skip difftastic for hidden revision buffers

### DIFF
--- a/magit-difftastic.el
+++ b/magit-difftastic.el
@@ -2131,6 +2131,15 @@ When nil, viewing a commit keeps Magit's stock rendering even while
   :type 'boolean
   :group 'magit-difftastic)
 
+(defcustom magit-difftastic-hidden-revision-buffers nil
+  "Whether to render hidden `magit-revision-mode' buffers with difftastic.
+Magit can refresh revision buffers that are not displayed in any window, for
+example while updating the revision buffer associated with another Magit view.
+When this option is nil, such hidden refreshes use Magit's stock revision diff
+instead of running difftastic."
+  :type 'boolean
+  :group 'magit-difftastic)
+
 ;; These are buffer-local variables Magit sets in its diff/revision buffers;
 ;; declare them special to keep the byte-compiler quiet.
 (defvar magit-buffer-range)
@@ -2290,6 +2299,8 @@ Falls back to ORIG (called with ARGS) when difftastic should not handle the
 current `magit-revision-mode' buffer.  Like Magit's own inserter, the per-file
 sections are inserted directly (no extra wrapping section)."
   (let ((ctx (and magit-difftastic-revision-buffers
+                  (or magit-difftastic-hidden-revision-buffers
+                      (get-buffer-window (current-buffer) t))
                   (ignore-errors (magit-difftastic--revision-context)))))
     (if ctx
         (magit-difftastic--insert-file-sections (cdr ctx) (car ctx))

--- a/test/magit-difftastic-test.el
+++ b/test/magit-difftastic-test.el
@@ -759,6 +759,43 @@ the render pump must not be able to re-enter `magit-refresh'."
         (magit-difftastic--render-files jobs width))
       (should observed))))
 
+;;;; Unit tests: revision-buffer visibility --------------------------------
+
+(ert-deftest magit-difftastic--insert-revision-diff-advice/hidden-falls-back ()
+  "Hidden revision buffers use the stock inserter by default."
+  (let ((magit-difftastic-revision-buffers t)
+        (magit-difftastic-hidden-revision-buffers nil)
+        (called-stock nil)
+        (called-context nil)
+        (called-insert nil))
+    (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+              ((symbol-function 'magit-difftastic--revision-context)
+               (lambda () (setq called-context t) '(:context . ("file"))))
+              ((symbol-function 'magit-difftastic--insert-file-sections)
+               (lambda (&rest _) (setq called-insert t))))
+      (magit-difftastic--insert-revision-diff-advice
+       (lambda (&rest _) (setq called-stock t))))
+    (should called-stock)
+    (should-not called-context)
+    (should-not called-insert)))
+
+(ert-deftest magit-difftastic--insert-revision-diff-advice/hidden-option-renders ()
+  "Hidden revision buffers can still render with difftastic when opted in."
+  (let ((magit-difftastic-revision-buffers t)
+        (magit-difftastic-hidden-revision-buffers t)
+        (called-stock nil)
+        (called-insert nil))
+    (cl-letf (((symbol-function 'get-buffer-window) (lambda (&rest _) nil))
+              ((symbol-function 'magit-difftastic--revision-context)
+               (lambda () '(:context . ("file"))))
+              ((symbol-function 'magit-difftastic--insert-file-sections)
+               (lambda (files context)
+                 (setq called-insert (list files context)))))
+      (magit-difftastic--insert-revision-diff-advice
+       (lambda (&rest _) (setq called-stock t))))
+    (should-not called-stock)
+    (should (equal called-insert '(("file") :context)))))
+
 ;;;; Unit tests: render cache ----------------------------------------------
 
 (ert-deftest magit-difftastic--cache-key/direct-and-nil ()


### PR DESCRIPTION
## Summary

Avoid rendering hidden `magit-revision-mode` buffers with difftastic by default. Magit can refresh a revision buffer even when it is no longer displayed in any window, for example while moving between commits or when another Magit view updates the associated revision buffer. In that hidden refresh path, running difftastic can block the UI while doing work the user cannot see.

This adds `magit-difftastic-hidden-revision-buffers`, defaulting to nil. Visible revision buffers still use difftastic when `magit-difftastic-revision-buffers` is enabled. Hidden revision buffers fall back to Magit's stock revision diff unless users explicitly opt in.

## Why

User diagnostics showed this sequence:

- The initially displayed `magit-show-commit` refresh completed quickly.
- A later `magit-revision-refresh-buffer` ran for the same revision with `(get-buffer-window (current-buffer) t)` returning nil.
- That hidden refresh entered `magit-difftastic--render-files` and blocked, even though the rendered output was not visible.

Skipping difftastic for hidden revision buffers avoids that background render path while preserving the normal visible commit-view behavior.

## Test

- `emacs --batch --eval '(progn (require (quote package)) (setq package-user-dir "/Users/misaka/.config/emacs/elpa" native-comp-jit-compilation nil) (package-initialize))' -L . -L test -l test/magit-difftastic-test.el --eval '(ert-run-tests-batch-and-exit (quote (or "magit-difftastic--insert-revision-diff-advice" "magit-difftastic-integration/render-files")))'`\n- `emacs --batch --eval '(progn (require (quote package)) (setq package-user-dir "/Users/misaka/.config/emacs/elpa" native-comp-jit-compilation nil) (package-initialize))' -L . --eval '(byte-compile-file "magit-difftastic.el")'`\n- `git diff --check`