### PR TITLE
fix: finish completed render processes while waiting

### DIFF
--- a/magit-difftastic.el
+++ b/magit-difftastic.el
@@ -343,12 +343,31 @@ a synchronous render."
          (max-jobs (magit-difftastic--max-jobs))
          (running 0)
          (pending (length jobs))
+         (active nil)
          ;; difft is selected purely through the environment (GIT_EXTERNAL_DIFF
          ;; etc.); the same env is reused for every process in the group.
          (env (difftastic--build-git-process-environment
                width (list "--display" magit-difftastic-display))))
     (cl-labels
-        ((launch ()
+        ((finish (p)
+           (when-let* ((entry (assq p active)))
+             (setq active (delq entry active))
+             (let ((file (cdr entry))
+                   (b (process-buffer p)))
+               (when (buffer-live-p b)
+                 (with-current-buffer b
+                   (when (eq (process-status p) 'exit)
+                     (puthash file
+                              (difftastic--ansi-color-apply (buffer-string))
+                              results)))
+                 (kill-buffer b)))
+             (cl-decf running)
+             (cl-decf pending)))
+         (finish-done ()
+           (dolist (entry (copy-sequence active))
+             (unless (process-live-p (car entry))
+               (finish (car entry)))))
+         (launch ()
            (while (and queue (< running max-jobs))
              (let* ((job (pop queue))
                     (file (car job))
@@ -358,22 +377,14 @@ a synchronous render."
                     (proc (apply #'start-file-process
                                  "magit-difftastic-render" buf "git" args)))
                (cl-incf running)
+               (push (cons proc file) active)
                (set-process-query-on-exit-flag proc nil)
                (set-process-sentinel
                 proc
                 (lambda (p _event)
-                  (unless (process-live-p p)
-                    (let ((b (process-buffer p)))
-                      (when (buffer-live-p b)
-                        (with-current-buffer b
-                          (puthash file
-                                   (difftastic--ansi-color-apply (buffer-string))
-                                   results))
-                        (kill-buffer b)))
-                    (cl-decf running)
-                    (cl-decf pending)
-                    ;; A finished slot frees room for the next queued job.
-                    (launch))))))))
+                  (finish p)
+                  ;; A finished slot frees room for the next queued job.
+                  (launch)))))))
       (launch)
       ;; Pump the event loop until every sentinel has fired.  We run inside a
       ;; `magit-refresh', and `accept-process-output' with a nil process drains
@@ -384,7 +395,13 @@ a synchronous render."
       ;; nested refresh a no-op; the outer refresh already reads fresh state.
       (let ((magit-inhibit-refresh t))
         (while (> pending 0)
-          (accept-process-output nil 0.05))))
+          (accept-process-output nil 0.05)
+          ;; Do not rely solely on sentinels to update `pending'.  In some
+          ;; refresh paths Emacs has already collected the process output but the
+          ;; sentinel does not run until user input interrupts the wait; polling
+          ;; completed processes here lets the render finish immediately.
+          (finish-done)
+          (launch))))
     results))
 
 ;;; Render cache


### PR DESCRIPTION
## Summary

`magit-difftastic--render-files` currently relies entirely on process sentinels to decrement `pending` and collect completed render output. In some Magit refresh paths, the `difft` process has already exited and its output buffer is available, but the sentinel does not advance the render state until user input interrupts the wait. The user-visible symptom is that Emacs appears stuck while rendering, then after `C-g` the difftastic output is already present and displays correctly.

This keeps the existing parallel `start-file-process` rendering and the existing `accept-process-output nil 0.05` wait, but tracks active render processes explicitly. After each wait tick, it polls the active processes; any process that is no longer live is finished from the main wait loop using the same buffer collection path as the sentinel. Sentinels still finish processes when they run normally.

## Why

Diagnostics showed `magit-difftastic--render-files` entering the wait loop after launching `difft`, with output becoming visible after `C-g`. That points to the wait loop depending too strongly on sentinel timing rather than on the actual process state. Polling completed processes lets the render finish even when sentinel dispatch is delayed.