### PR TITLE
fix: visit the row at point; parent chunk section map on magit-hunk-section-map

### DIFF
--- a/magit-difftastic.el
+++ b/magit-difftastic.el
@@ -608,9 +608,10 @@ is always re-rendered."
                  (oref file-section children))))
 
 (defun magit-difftastic-visit-file-dwim (&optional display)
-  "Visit the file enclosing point, jumping to the chunk's first change.
-When on a chunk, jump to its first new-side line (read from the chunk's rendered
-gutters); falls back to the chunk's stored gutter line.
+  "Visit the file enclosing point, jumping to the line at point.
+When on a chunk body row, jump to that row's worktree line; when on the chunk
+heading, jump to the chunk's first new-side line (both read from the chunk's
+rendered gutters); falls back to the chunk's stored gutter line.
 On a file heading (not a chunk), behaves as if point were on the file's first
 chunk.  DISPLAY, when `other-window' or `other-frame', visits the file in
 another window or frame (mirroring Magit's `*-other-window'/`*-other-frame'
@@ -751,11 +752,33 @@ is unavailable."
           (forward-line))))
     (cons (nreverse old) (nreverse new))))
 
+(defun magit-difftastic--chunk-line-at-point (section)
+  "Return the worktree line for the chunk row at point in SECTION, or nil.
+Resolves the parsed row containing point (correct for all layouts, including
+wrapped rows): prefers the row's new-side (rhs) number, then its old-side
+\(lhs) number for rows shown only on the old side, then the next row with a
+new-side number.  Nil when point is not on a body row (e.g. the chunk
+heading) or difftastic's parser is unavailable."
+  (when-let* ((rows (magit-difftastic--parse-chunk-lines section))
+              (tail (seq-drop-while
+                     (pcase-lambda (`((,_beg ,end) ,_left ,_right))
+                       (< end (point)))
+                     rows))
+              (row (car tail)))
+    (pcase-let ((`((,beg ,_end) ,left ,right) row))
+      (when (<= beg (point))
+        (or (car right)
+            (car left)
+            (cl-some (pcase-lambda (`(,_beg-end ,_left ,right))
+                       (car right))
+                     (cdr tail)))))))
+
 (defun magit-difftastic--chunk-visit-line (section)
   "Return the 1-based worktree line to visit for chunk SECTION, or nil.
-Prefers the chunk's first new-side (rhs) displayed line, so visiting lands on
-the change in the worktree; falls back to the first old-side (lhs) line for a
-pure deletion.
+Prefers the row at point (see `magit-difftastic--chunk-line-at-point'), so
+visiting lands on the row under the cursor.  When point is not on a body
+row (chunk or file heading), falls back to the chunk's first new-side (rhs)
+displayed line, then to the first old-side (lhs) line for a pure deletion.
 
 Read from SECTION's rendered gutters (see
 `magit-difftastic--chunk-displayed-lines'), so it follows whatever the section
@@ -766,8 +789,9 @@ ordinals can drift from the displayed sections).
 tokens for recognized languages -- for plain text every span is `normal' -- so
 a derived column would be misleading.  Visiting lands on the line and its first
 non-whitespace character instead.)"
-  (let ((lines (magit-difftastic--chunk-displayed-lines section)))
-    (or (car (cdr lines)) (car (car lines)))))
+  (or (magit-difftastic--chunk-line-at-point section)
+      (let ((lines (magit-difftastic--chunk-displayed-lines section)))
+        (or (car (cdr lines)) (car (car lines))))))
 
 (defun magit-difftastic--chunk-patch (section)
   "Build a standalone git patch string for the chunk SECTION, or nil.

--- a/magit-difftastic.el
+++ b/magit-difftastic.el
@@ -2351,12 +2351,17 @@ next time `magit-difftastic-mode' is enabled)."
            (magit-difftastic--set-evil-keys t))))
 
 (defvar magit-difftastic-hunk-section-map
-  (make-sparse-keymap)
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map magit-hunk-section-map)
+    map)
   "Keymap installed on difftastic chunk (`magit-difftastic-hunk') sections.
 Attached via each section's `:keymap' slot (see
-`magit-difftastic--insert-chunk').  `magit-difftastic-mode' adds
-`magit-difftastic-toggle-rendering-key' here while enabled; unbound keys fall
-through to the Magit maps as usual.")
+`magit-difftastic--insert-chunk').  Parented on `magit-hunk-section-map',
+since a section's keymap replaces Magit's own: without the parent, keys bound
+only there (e.g. `C-j' -> `magit-diff-visit-worktree-file') would fall through
+to the global map.  The inherited visit/discard commands are advised while the
+mode is on (see `magit-difftastic--advices').  `magit-difftastic-mode' adds
+`magit-difftastic-toggle-rendering-key' here while enabled.")
 
 (defun magit-difftastic--set-toggle-key (enable)
   "Bind (ENABLE non-nil) or unbind the file-rendering toggle key.

--- a/test/magit-difftastic-test.el
+++ b/test/magit-difftastic-test.el
@@ -242,6 +242,18 @@ definitions) so they fall through to the user's own bindings."
       (should calls)
       (should-not (cl-some #'cdr calls)))))
 
+;;;; Unit tests: section keymap --------------------------------------------
+
+(ert-deftest magit-difftastic-hunk-section-map/parents-magit-hunk-map ()
+  "The chunk section map inherits Magit's hunk section map.
+A section's keymap replaces Magit's own, so keys bound only there
+\(e.g. `C-j') must come through the parent."
+  (should (eq (keymap-parent magit-difftastic-hunk-section-map)
+              magit-hunk-section-map))
+  ;; `C-j' resolves through the parent to a real command.
+  (should (commandp (lookup-key magit-difftastic-hunk-section-map
+                                (kbd "C-j")))))
+
 ;;;; Unit tests: width / wrapping knob -------------------------------------
 
 (ert-deftest magit-difftastic--width/honors-custom ()

--- a/test/magit-difftastic-test.el
+++ b/test/magit-difftastic-test.el
@@ -296,6 +296,48 @@ A section's keymap replaces Magit's own, so keys bound only there
                 (when (car left)  (should (<= 1 (car left) 7)))
                 (when (car right) (should (<= 1 (car right) 7)))))))))))
 
+;;;; Integration: visiting -------------------------------------------------
+
+(ert-deftest magit-difftastic-integration/visit-line-resolves-row-at-point ()
+  "Visiting resolves the worktree line of the row at point in every layout.
+On a body row the row's own new-side line wins -- visiting from the middle of
+a chunk must not jump to the chunk's first change.  On the chunk heading the
+historic first-change fallback applies."
+  (skip-unless dst-test--have-tools)
+  (skip-unless (fboundp 'difftastic--parse-single-column-chunk))
+  (dolist (display dst-test--displays)
+    (dst-test--with-repo `(("sample.txt" . ,dst-test--old))
+        `(("sample.txt" . ,dst-test--new))
+      (let ((magit-difftastic-display display))
+        (with-temp-buffer
+          (insert (dst-test--chunk-buffer-string "sample.txt" display))
+          (goto-char (point-min))
+          (let ((sec (dst-test--make-section
+                      (point-min) (line-end-position) (point-max))))
+            ;; Heading row: no body row at point -> first-change fallback.
+            (should-not (magit-difftastic--chunk-line-at-point sec))
+            (let ((lines (magit-difftastic--chunk-displayed-lines sec)))
+              (should (equal (magit-difftastic--chunk-visit-line sec)
+                             (or (car (cdr lines)) (car (car lines))))))
+            ;; A change in the middle of the chunk resolves to ITS line.
+            (goto-char (point-min))
+            (search-forward "delta-modified")
+            (should (equal 4 (magit-difftastic--chunk-visit-line sec)))
+            (if (equal display "inline")
+                ;; An old-side-only row resolves via its old-side line.
+                (progn
+                  (goto-char (point-min))
+                  (re-search-forward "^4 +delta$")
+                  (should (equal 4 (magit-difftastic--chunk-visit-line sec))))
+              ;; A context row (only displayed side-by-side) likewise.
+              (goto-char (point-min))
+              (search-forward "charlie")
+              (should (equal 3 (magit-difftastic--chunk-visit-line sec))))
+            ;; The trailing addition resolves to the last new line.
+            (goto-char (point-min))
+            (search-forward "golf-added")
+            (should (equal 7 (magit-difftastic--chunk-visit-line sec)))))))))
+
 ;;;; Integration: region (line-range) staging ------------------------------
 
 (ert-deftest magit-difftastic-integration/region-staging-resolves ()


### PR DESCRIPTION
First off -- thank you for this package! Difftastic rendering with native chunk staging inside Magit is fantastic, and it has become part of my daily workflow. This PR fixes two small issues I ran into with the visit commands.

## Fix 1: `C-j`/`RET` visits the chunk's first change instead of the row at point

`magit-difftastic--chunk-visit-line` always returned the chunk's first new-side displayed line, so visiting from the middle of a chunk missed the cursor's row -- e.g. with point on a row for line 56, `C-j` landed on line 51 (the chunk's first change).

The fix resolves the parsed row containing point via difftastic's own parser (`difftastic--parse-side-by-side-chunk` / `difftastic--parse-single-column-chunk`, which the package already uses for staging), so inline and both side-by-side layouts, including wrapped rows, are handled:

- prefer the row's new-side (rhs) line number;
- fall back to its old-side (lhs) number for rows shown only on the old side (pure deletions, difft's inline old block);
- as a last resort, use the next row with a new-side number.

Point on the chunk heading (or a file heading) keeps the historic first-change behavior. This mirrors what `difftastic--chunk-file-at-point` does in the difftastic package itself.

## Fix 2: section-map-only keys fall through to the global map

The docstring of `magit-difftastic-hunk-section-map` says unbound keys "fall through to the Magit maps as usual", but a section's keymap *replaces* Magit's own section keymap rather than augmenting it. Keys that live only in `magit-hunk-section-map` -- notably `C-j` -> `magit-diff-visit-worktree-file` in vanilla Magit -- fell through to the *global* map on difftastic chunks, so `C-j` inserted a newline (`electric-newline-and-maybe-indent`) instead of visiting the file.

Parenting the map on `magit-hunk-section-map` restores the stock-hunk behavior; the inherited visit/discard commands are already advised while the mode is on, so they do the right thing on difftastic sections.

## Testing

- Added an integration test (`visit-line-resolves-row-at-point`) covering all three display modes: heading fallback, mid-chunk change, context row, old-side-only row, and trailing addition.
- Added a unit test for the keymap parent.
- Full suite: 45 tests, 42 pass; the 3 `diff-context-*` failures are pre-existing on `main` against current Magit (4.6-dev renamed `magit-buffer-typearg`) and unrelated to this change.
- Byte-compiles with no new warnings (Emacs 30.2, magit 20260718, difftastic 20260408, difft 0.69.0).
- Both fixes have also been running in my own config (as advice/patches) in daily use.

## Disclosure

I used an AI assistant to help draft these changes; I reviewed everything and verified the behavior locally in a running Emacs. Happy to make any changes you'd like -- naming, fallback order, splitting or squashing the commits, whatever fits the project best.